### PR TITLE
Fix container width constraint

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,9 +42,6 @@ p{ margin: 0 0 14px; color: var(--muted); }
 
 .container{
   width: 100%;
-  max-width: --var;
-}
-.container{
   max-width: var(--maxw);
   margin: 0 auto;
   padding: 0 20px;


### PR DESCRIPTION
## Summary
- ensure the main layout container uses the intended CSS custom property for its max width
- consolidate the duplicate `.container` rules to keep the width, margin, and padding declarations in one place

## Testing
- manually opened http://127.0.0.1:8000/ in a browser to verify the layout width constraint

------
https://chatgpt.com/codex/tasks/task_e_68c9dd1c10d0832dbb1297005ee72ed3